### PR TITLE
Don't reseed RNG every time

### DIFF
--- a/Game/Assets/Scripts/CityMap/CityMap.cs
+++ b/Game/Assets/Scripts/CityMap/CityMap.cs
@@ -21,6 +21,7 @@ namespace Game.CityMap
         public GameObject parent;
         public Text display;
         private int[,] terrainMap;
+        private Random random = new Random();
 
         public MapTile[] Tiles
         {
@@ -78,7 +79,6 @@ namespace Game.CityMap
                 {
                     MapTile tile = ScriptableObject.CreateInstance<MapTile>();
                     tile.Terrain = new TestTerrain();
-                    Random random = new Random();
                     int value = random.Next(0, 2);
                     // A vector used for hex position
                     Vector3Int vector = new Vector3Int(-i + width / 2, -j + height / 2, 0);


### PR DESCRIPTION
The randomness didn't feel random at all previously, because a new Random object seeded with the current time was created every time a new random number is needed. However, since the time between the RNG invocations is very very small, many random numbers come from the same seed and end up with the same value.

Here, we just seed the Random object once at the beginning, and reuse the Random object throughout the CityMap's lifetime.