### PR TITLE
Re-add prefix and number format to tooltips

### DIFF
--- a/Game/Assets/Scripts/StatsBar.cs
+++ b/Game/Assets/Scripts/StatsBar.cs
@@ -245,12 +245,12 @@ namespace Game
                 this.value = value;
                 if (change > 0)
                 {
-                    tooltipQueue?.Add("+" + change + suffix + explainer);
+                    tooltipQueue?.Add("+" + change.ToString(format) + suffix + explainer);
                 }
                 else if (change < 0)
                 {
                     change *= -1;
-                    tooltipQueue?.Add("-" + change + suffix + explainer);
+                    tooltipQueue?.Add("-" + change.ToString(format) + suffix + explainer);
                 }
                 ChangeEvent?.Invoke();
             }


### PR DESCRIPTION
E.g., the dollar sign in front of money change tooltips